### PR TITLE
Make fontWeight String

### DIFF
--- a/src/components/Table/styleSheets.js
+++ b/src/components/Table/styleSheets.js
@@ -38,14 +38,14 @@ export const normalStyle = StyleSheet.create({
   },
   tdText: {
     // textAlign: 'left',
-    fontWeight: table.tdFontWeight,
+    fontWeight: String(table.tdFontWeight),
     color: table.fontColor,
     fontSize: table.fontSize,
     fontFamily: 'PingFang SC',
     lineHeight: table.lineHeight,
   },
   thText: {
-    fontWeight: table.thFontWeight,
+    fontWeight: String(table.thFontWeight),
     color: table.thFontColor,
     fontFamily: 'PingFang SC',
     lineHeight: table.lineHeight,


### PR DESCRIPTION
since react-sketchapp has changed the way to define fontWeight: https://github.com/airbnb/react-sketchapp/commit/a2f92927ac737559f63330219975f70cd6d377b8#diff-a2d56bbaa3d24ee97226775f3d6a4542

a fine fontWeight should be like '500' instead of 500, ow error `style.fontWeight.toLowerCase is not a function`